### PR TITLE
Fix: Actually Register SW14 for button press events

### DIFF
--- a/Firmware/CoverUI_V2/src/main.cpp
+++ b/Firmware/CoverUI_V2/src/main.cpp
@@ -213,7 +213,7 @@ void setup() {
     }
 
 #ifndef TEST_MODE
-    for (int i = 0; i < 13; ++i) {
+    for (int i = 0; i < 14; ++i) {
         SW[i].onPress([](int idx, int v, int up) {
             // v is 0 for release, 1-2-3 for press length
             if (v > 0)


### PR DESCRIPTION
SW14 has never been registered for button press events. The loop ignores it, because it's missing the last iteration.

This was most likely a copy & paste mistake from the TEST_MODE code below where SW14 is handled specially and not by a loop iterating over all buttons.

edit: I tested this by disassembling and then binary patching the firmware I downloaded from the GitHub releases. I have no idea how to use platform.io to recompile this. My binary patch works on my hardware. I can't see why this patch here would fail.